### PR TITLE
Decoding base64 encoded request body

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -91,7 +91,7 @@ class LambdaResponse(object):
 
 class FlaskLambda(Flask):
     def __call__(self, event, context):
-        if 'isBase64Encoded' in event and event['isBase64Encoded']:
+        if event.get('isBase64Encoded', False):
             event['body'] = base64.b64decode(event['body'])
         if 'httpMethod' not in event:
             # In this "context" `event` is `environ` and

--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -91,8 +91,6 @@ class LambdaResponse(object):
 
 class FlaskLambda(Flask):
     def __call__(self, event, context):
-        if event.get('isBase64Encoded', False):
-            event['body'] = base64.b64decode(event['body'])
         if 'httpMethod' not in event:
             # In this "context" `event` is `environ` and
             # `context` is `start_response`, meaning the request didn't
@@ -100,6 +98,9 @@ class FlaskLambda(Flask):
             return super(FlaskLambda, self).__call__(event, context)
 
         response = LambdaResponse()
+        
+        if event.get('isBase64Encoded', False):
+            event['body'] = base64.b64decode(event['body'])
 
         body = next(self.wsgi_app(
             make_environ(event),

--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 import sys
+import base64
 
 try:
     from urllib import urlencode
@@ -90,6 +91,8 @@ class LambdaResponse(object):
 
 class FlaskLambda(Flask):
     def __call__(self, event, context):
+        if event['isBase64Encoded']:
+            event['body'] = base64.b64decode(event['body'])
         if 'httpMethod' not in event:
             # In this "context" `event` is `environ` and
             # `context` is `start_response`, meaning the request didn't

--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -91,7 +91,7 @@ class LambdaResponse(object):
 
 class FlaskLambda(Flask):
     def __call__(self, event, context):
-        if event['isBase64Encoded']:
+        if 'isBase64Encoded' in event and event['isBase64Encoded']:
             event['body'] = base64.b64decode(event['body'])
         if 'httpMethod' not in event:
             # In this "context" `event` is `environ` and


### PR DESCRIPTION
- When using binary media types in API gateway, request bodies are base64 encoded. This allows the body to be decoded.