### PR TITLE
fix bug whene use sam local

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -50,6 +50,9 @@ def make_environ(event):
         environ[http_hdr_name] = hdr_value
 
     qs = event['queryStringParameters']
+    environ['HTTP_HOST'] = environ.get('HTTP_HOST') or 'localhost'
+    environ['HTTP_X_FORWARDED_PORT'] = environ.get('HTTP_X_FORWARDED_PORT') or 8888
+    environ['HTTP_X_FORWARDED_PROTO'] = environ.get('HTTP_X_FORWARDED_PROTO') or 8888
 
     environ['REQUEST_METHOD'] = event['httpMethod']
     environ['PATH_INFO'] = event['path']


### PR DESCRIPTION
when use 'sam local start-api' there is a error, so should set the default value first.
there is a key error, like:
```
START RequestId: 23366b07-fe7f-4e1c-9c2b-5141843846da Version: $LATEST
'HTTP_X_FORWARDED_PROTO': KeyError
Traceback (most recent call last):
  File "/var/task/flask_lambda.py", line 104, in __call__
    make_environ(event),
  File "/var/task/flask_lambda.py", line 70, in make_environ
    environ['wsgi.url_scheme'] = environ['HTTP_X_FORWARDED_PROTO']
KeyError: 'HTTP_X_FORWARDED_PROTO'
```